### PR TITLE
Add ci.yml workflow file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: ci
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23.0"
+
+      - name: Force Failure
+        run: (exit 1)


### PR DESCRIPTION
This pull request adds a new Continuous Integration (CI) workflow using a ci.yml file in the .github/workflows directory. The workflow is configured to run on every pull request and is intentionally designed to fail to confirm that the CI pipeline is functioning correctly.