### PR TITLE
Add CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
+![CI Status](https://github.com/ZombeyFan99/learn-cicd-starter/actions/workflows/ci.yml/badge.svg)
 # learn-cicd-starter (Notely)
+
 
 This repo contains the starter code for the "Notely" application for the "Learn CICD" course on [Boot.dev](https://boot.dev).
 


### PR DESCRIPTION
This pull request adds a dynamic CI status badge to the README.md file. This badge will display the real-time status of the project's tests, providing a quick visual indicator of the build health.